### PR TITLE
Sample actions with RxR baseline models

### DIFF
--- a/vlnce_baselines/config/rxr_baselines/rxr_cma_en.yaml
+++ b/vlnce_baselines/config/rxr_baselines/rxr_cma_en.yaml
@@ -20,8 +20,9 @@ INFERENCE:
 EVAL:
   USE_CKPT_CONFIG: False
   SPLIT: val_unseen
+  LANGUAGES: [en-US, en-IN]
   EPISODE_COUNT: -1
-  SAMPLE: False
+  SAMPLE: True
 
 RL:
   POLICY:

--- a/vlnce_baselines/config/rxr_baselines/rxr_cma_hi.yaml
+++ b/vlnce_baselines/config/rxr_baselines/rxr_cma_hi.yaml
@@ -20,8 +20,9 @@ INFERENCE:
 EVAL:
   USE_CKPT_CONFIG: False
   SPLIT: val_unseen
+  LANGUAGES: [hi-IN]
   EPISODE_COUNT: -1
-  SAMPLE: False
+  SAMPLE: True
 
 RL:
   POLICY:

--- a/vlnce_baselines/config/rxr_baselines/rxr_cma_te.yaml
+++ b/vlnce_baselines/config/rxr_baselines/rxr_cma_te.yaml
@@ -20,8 +20,9 @@ INFERENCE:
 EVAL:
   USE_CKPT_CONFIG: False
   SPLIT: val_unseen
+  LANGUAGES: [te-IN]
   EPISODE_COUNT: -1
-  SAMPLE: False
+  SAMPLE: True
 
 RL:
   POLICY:


### PR DESCRIPTION
The baseline model for the RxR-Habitat Challenge was evaluated with sampled actions, but the configs show `EVAL.SAMPLE: False`. Update each config to use sampled actions. This discrepancy was found thanks to #24.  Also specifies the evaluation language each monolingual model was trained for.