### PR TITLE
Cast R2R episode_id to string

### DIFF
--- a/habitat_extensions/measures.py
+++ b/habitat_extensions/measures.py
@@ -268,7 +268,7 @@ class NDTW(Measure):
 
     def reset_metric(self, *args: Any, episode, **kwargs: Any):
         self.locations = []
-        self.gt_locations = self.gt_json[str(episode.episode_id)]["locations"]
+        self.gt_locations = self.gt_json[episode.episode_id]["locations"]
         self.update_metric()
 
     def update_metric(self, *args: Any, **kwargs: Any):

--- a/habitat_extensions/task.py
+++ b/habitat_extensions/task.py
@@ -86,6 +86,10 @@ class VLNCEDatasetV1(Dataset):
         )
 
         for episode in deserialized["episodes"]:
+            # cast integer IDs to strings
+            episode["episode_id"] = str(episode["episode_id"])
+            episode["trajectory_id"] = str(episode["trajectory_id"])
+
             episode = VLNExtendedEpisode(**episode)
 
             if scenes_dir is not None:

--- a/habitat_extensions/utils.py
+++ b/habitat_extensions/utils.py
@@ -641,7 +641,7 @@ def generate_video(
     video_option: List[str],
     video_dir: Optional[str],
     images: List[ndarray],
-    episode_id: int,
+    episode_id: Union[str, int],
     checkpoint_idx: int,
     metrics: Dict[str, float],
     tb_writer: TensorboardWriter,

--- a/vlnce_baselines/common/recollection_dataset.py
+++ b/vlnce_baselines/common/recollection_dataset.py
@@ -74,7 +74,7 @@ class TeacherRecollectionDataset(torch.utils.data.IterableDataset):
             self.config.TASK_CONFIG.TASK.INSTRUCTION_SENSOR_UUID,
         )
         for i, ep in enumerate(self.envs.current_episodes()):
-            path_step = self.trajectories[str(ep.episode_id)][0]
+            path_step = self.trajectories[ep.episode_id][0]
             self._env_observations[i].append(
                 (
                     observations[i],
@@ -181,7 +181,7 @@ class TeacherRecollectionDataset(torch.utils.data.IterableDataset):
 
             # get the next action for each env
             actions = [
-                self.trajectories[str(ep.episode_id)][self.env_step[i]][1]
+                self.trajectories[ep.episode_id][self.env_step[i]][1]
                 for i, ep in enumerate(current_episodes)
             ]
 
@@ -198,7 +198,7 @@ class TeacherRecollectionDataset(torch.utils.data.IterableDataset):
                 self.env_step[i] += 1
                 if dones[i]:
                     assert len(self._env_observations[i]) == len(
-                        self.trajectories[str(prev_eps[i].episode_id)]
+                        self.trajectories[prev_eps[i].episode_id]
                     ), "Collected episode does not match the step count of trajectory"
                     self._preload.append(
                         (
@@ -210,9 +210,9 @@ class TeacherRecollectionDataset(torch.utils.data.IterableDataset):
                     self._env_observations[i] = []
                     self.env_step[i] = 0
 
-                path_step = self.trajectories[
-                    str(current_episodes[i].episode_id)
-                ][self.env_step[i]]
+                path_step = self.trajectories[current_episodes[i].episode_id][
+                    self.env_step[i]
+                ]
                 self._env_observations[i].append(
                     (
                         observations[i],


### PR DESCRIPTION
Regarding Issue #27.

Currently, R2R episode IDs are integers and RxR episode IDs are strings. This causes problems in the RecollectTrainer, which saves json files with episode IDs as keys. The keys are auto-casted to strings which breaks R2R + RecollectTrainer compatibility. This PR re-defines R2R episode IDs to be strings to avoid this problem. Habitat-Lab expects episode IDs to be strings anyway ([defined here](https://github.com/facebookresearch/habitat-lab/blob/d6ed1c0a0e786f16f261de2beafe347f4186d0d8/habitat/core/dataset.py#L56)), so this should be done regardless of bug fixing.

Testing: I confirmed that the RecollectTrainer initializes properly for both R2R and RxR datasets.