### PR TITLE
Update R2R_VLNCE dataset to v1-3

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,20 +63,20 @@ Extract such that it has the form `data/scene_datasets/mp3d/{scene}/{scene}.glb`
 
 #### Episodes: Room-to-Room (R2R)
 
-The R2R_VLNCE dataset is a port of the Room-to-Room (R2R) dataset created by [Anderson et al](http://openaccess.thecvf.com/content_cvpr_2018/papers/Anderson_Vision-and-Language_Navigation_Interpreting_CVPR_2018_paper.pdf) for use with the [Matterport3DSimulator](https://github.com/peteanderson80/Matterport3DSimulator) (MP3D-Sim). For details on the porting process from MP3D-Sim to the continuous reconstructions used in Habitat, please see our [paper](https://arxiv.org/abs/2004.02857). We provide two versions of the dataset, `R2R_VLNCE_v1-2` and `R2R_VLNCE_v1-2_preprocessed`. `R2R_VLNCE_v1-2` contains the `train`, `val_seen`, `val_unseen`, and `test` splits. `R2R_VLNCE_v1-2_preprocessed` runs with our models out of the box. It additionally includes instruction tokens mapped to GloVe embeddings, ground truth trajectories, and a data augmentation split (`envdrop`) that is ported from [R2R-EnvDrop](https://github.com/airsplay/R2R-EnvDrop). The `test` split does not contain episode goals or ground truth paths. For more details on the dataset contents and format, see our [project page](https://jacobkrantz.github.io/vlnce/data).
+The R2R_VLNCE dataset is a port of the Room-to-Room (R2R) dataset created by [Anderson et al](http://openaccess.thecvf.com/content_cvpr_2018/papers/Anderson_Vision-and-Language_Navigation_Interpreting_CVPR_2018_paper.pdf) for use with the [Matterport3DSimulator](https://github.com/peteanderson80/Matterport3DSimulator) (MP3D-Sim). For details on porting to 3D reconstructions, please see our [paper](https://arxiv.org/abs/2004.02857). `R2R_VLNCE_v1-3` is a minimal version of the dataset and `R2R_VLNCE_v1-3_preprocessed` runs baseline models out of the box. See the [dataset page](https://jacobkrantz.github.io/vlnce/data) for format, contents, and a changelog. We encourage use of the most recent version (`v1-3`).
 
 | Dataset | Extract path | Size |
 |-------------- |---------------------------- |------- |
-| [R2R_VLNCE_v1-2.zip](https://drive.google.com/file/d/1YDNWsauKel0ht7cx15_d9QnM6rS4dKUV/view) | `data/datasets/R2R_VLNCE_v1-2` | 3 MB |
-| [R2R_VLNCE_v1-2_preprocessed.zip](https://drive.google.com/file/d/18sS9c2aRu2EAL4c7FyG29LDAm2pHzeqQ/view) | `data/datasets/R2R_VLNCE_v1-2_preprocessed` | 345 MB |
+| [R2R_VLNCE_v1-3.zip](https://drive.google.com/file/d/1qrdomxA5fuQ6n44NXzPAJe2dMdxatvma/view) | `data/datasets/R2R_VLNCE_v1-3` | 3 MB |
+| [R2R_VLNCE_v1-3_preprocessed.zip](https://drive.google.com/file/d/1kQ_at68wiK2vAmlWbjJ4EDrLtaM0nfkR/view) | `data/datasets/R2R_VLNCE_v1-3_preprocessed` | 250 MB |
 
-Downloading the dataset:
+Downloading via CLI:
 
 ```bash
-# R2R_VLNCE_v1-2
-gdown https://drive.google.com/uc?id=1YDNWsauKel0ht7cx15_d9QnM6rS4dKUV
-# R2R_VLNCE_v1-2_preprocessed
-gdown https://drive.google.com/uc?id=18sS9c2aRu2EAL4c7FyG29LDAm2pHzeqQ
+# R2R_VLNCE_v1-3
+gdown https://drive.google.com/uc?id=1qrdomxA5fuQ6n44NXzPAJe2dMdxatvma
+# R2R_VLNCE_v1-3_preprocessed
+gdown https://drive.google.com/uc?id=1kQ_at68wiK2vAmlWbjJ4EDrLtaM0nfkR
 ```
 
 ##### Encoder Weights

--- a/habitat_extensions/config/default.py
+++ b/habitat_extensions/config/default.py
@@ -65,7 +65,7 @@ _C.TASK.NDTW.TYPE = "NDTW"
 _C.TASK.NDTW.SPLIT = "val_seen"
 _C.TASK.NDTW.FDTW = True  # False: DTW
 _C.TASK.NDTW.GT_PATH = (
-    "data/datasets/R2R_VLNCE_v1-2_preprocessed/{split}/{split}_gt.json.gz"
+    "data/datasets/R2R_VLNCE_v1-3_preprocessed/{split}/{split}_gt.json.gz"
 )
 _C.TASK.NDTW.SUCCESS_DISTANCE = 3.0
 # ----------------------------------------------------------------------------

--- a/habitat_extensions/config/vlnce_task.yaml
+++ b/habitat_extensions/config/vlnce_task.yaml
@@ -41,9 +41,9 @@ TASK:
   SPL:
     SUCCESS_DISTANCE: 3.0
   NDTW:
-    GT_PATH: data/datasets/R2R_VLNCE_v1-2_preprocessed/{split}/{split}_gt.json.gz
+    GT_PATH: data/datasets/R2R_VLNCE_v1-3_preprocessed/{split}/{split}_gt.json.gz
 DATASET:
   TYPE: VLN-CE-v1
   SPLIT: train
-  DATA_PATH: data/datasets/R2R_VLNCE_v1-2_preprocessed/{split}/{split}.json.gz
+  DATA_PATH: data/datasets/R2R_VLNCE_v1-3_preprocessed/{split}/{split}.json.gz
   SCENES_DIR: data/scene_datasets/

--- a/habitat_extensions/config/vlnce_task_aug.yaml
+++ b/habitat_extensions/config/vlnce_task_aug.yaml
@@ -44,9 +44,9 @@ TASK:
   SPL:
     SUCCESS_DISTANCE: 3.0
   NDTW:
-    GT_PATH: data/datasets/R2R_VLNCE_v1-2_preprocessed/{split}/{split}_gt.json.gz
+    GT_PATH: data/datasets/R2R_VLNCE_v1-3_preprocessed/{split}/{split}_gt.json.gz
 DATASET:
   TYPE: VLN-CE-v1
   SPLIT: joint_train_envdrop
-  DATA_PATH: data/datasets/R2R_VLNCE_v1-2_preprocessed/{split}/{split}.json.gz
+  DATA_PATH: data/datasets/R2R_VLNCE_v1-3_preprocessed/{split}/{split}.json.gz
   SCENES_DIR: data/scene_datasets/

--- a/habitat_extensions/config/vlnce_waypoint_task.yaml
+++ b/habitat_extensions/config/vlnce_waypoint_task.yaml
@@ -52,9 +52,9 @@ TASK:
   SPL:
     SUCCESS_DISTANCE: 3.0
   NDTW:
-    GT_PATH: data/datasets/R2R_VLNCE_v1-2_preprocessed/{split}/{split}_gt.json.gz
+    GT_PATH: data/datasets/R2R_VLNCE_v1-3_preprocessed/{split}/{split}_gt.json.gz
 DATASET:
   TYPE: VLN-CE-v1
   SPLIT: train
-  DATA_PATH: data/datasets/R2R_VLNCE_v1-2_preprocessed/{split}/{split}.json.gz
+  DATA_PATH: data/datasets/R2R_VLNCE_v1-3_preprocessed/{split}/{split}.json.gz
   SCENES_DIR: data/scene_datasets/

--- a/vlnce_baselines/config/default.py
+++ b/vlnce_baselines/config/default.py
@@ -224,10 +224,10 @@ _C.MODEL.INSTRUCTION_ENCODER.sensor_uuid = "instruction"
 _C.MODEL.INSTRUCTION_ENCODER.vocab_size = 2504
 _C.MODEL.INSTRUCTION_ENCODER.use_pretrained_embeddings = True
 _C.MODEL.INSTRUCTION_ENCODER.embedding_file = (
-    "data/datasets/R2R_VLNCE_v1-2_preprocessed/embeddings.json.gz"
+    "data/datasets/R2R_VLNCE_v1-3_preprocessed/embeddings.json.gz"
 )
 _C.MODEL.INSTRUCTION_ENCODER.dataset_vocab = (
-    "data/datasets/R2R_VLNCE_v1-2_preprocessed/train/train.json.gz"
+    "data/datasets/R2R_VLNCE_v1-3_preprocessed/train/train.json.gz"
 )
 _C.MODEL.INSTRUCTION_ENCODER.fine_tune_embeddings = False
 _C.MODEL.INSTRUCTION_ENCODER.embedding_size = 50

--- a/vlnce_baselines/config/r2r_baselines/cma.yaml
+++ b/vlnce_baselines/config/r2r_baselines/cma.yaml
@@ -19,7 +19,7 @@ IL:
 
   RECOLLECT_TRAINER:
     gt_file:
-      data/datasets/R2R_VLNCE_v1-2_preprocessed/{split}/{split}_gt.json.gz
+      data/datasets/R2R_VLNCE_v1-3_preprocessed/{split}/{split}_gt.json.gz
 
   DAGGER:
     iterations: 1

--- a/vlnce_baselines/config/r2r_baselines/seq2seq.yaml
+++ b/vlnce_baselines/config/r2r_baselines/seq2seq.yaml
@@ -19,7 +19,7 @@ IL:
 
   RECOLLECT_TRAINER:
     gt_file:
-      data/datasets/R2R_VLNCE_v1-2_preprocessed/{split}/{split}_gt.json.gz
+      data/datasets/R2R_VLNCE_v1-3_preprocessed/{split}/{split}_gt.json.gz
 
   DAGGER:
     iterations: 1


### PR DESCRIPTION
This PR updates the `R2R_VLNCE` dataset from `v1_2` to `v1_3`. Initial episode heading have been altered to match the initial headings in Room-to-Room. We encourage updating to the latest version of the dataset. Full detail of this change and its implications can be found on the dataset webpage page [jacobkrantz.github.io/vlnce/data](https://jacobkrantz.github.io/vlnce/data). Changelog included here for completeness:

### R2R_VLNCE_v1-3 [Feb 3, 2022]

In versions v1-2 and earlier, initial episode headings did not match the headings in Room-to-Room (R2R). Release v1-3 modifies initial headings to match R2R. Associated changes include:

- New initial episode headings
- Recomputed ground-truth oracle navigation paths
- Pruned 109 augmentation episodes (0.07%) from the Envdrop split that are no longer navigable

Path evaluations on the leaderboard are unaffected by this change and previous submissions remain valid.

#### Affect On Agent Performance

We evaluated the published weights of the CMA_PM_DA baseline with the new dataset headings. In val-unseen, Success Rate increased from 29 to 30 and SPL increased from 27 to 28. We also trained and evaluated a CMA model (CMA_TF) with dataset versions v1-2 and v1-3. We found that v1-3 resulted in a 1 point increase in both SR and SPL. This is within the typical variance observed when repeating experiments.

Addresses issues #29, #15 