### PR TITLE
Baselines bug fixes

### DIFF
--- a/vlnce_baselines/config/r2r_baselines/test_set_inference.yaml
+++ b/vlnce_baselines/config/r2r_baselines/test_set_inference.yaml
@@ -9,6 +9,7 @@ INFERENCE:
   SAMPLE: False
   CKPT_PATH: data/checkpoints/CMA_PM_DA_Aug.pth
   PREDICTIONS_FILE: predictions.json
+  FORMAT: r2r
 
 MODEL:
   policy_name: CMAPolicy

--- a/vlnce_baselines/models/encoders/instruction_encoder.py
+++ b/vlnce_baselines/models/encoders/instruction_encoder.py
@@ -75,7 +75,7 @@ class InstructionEncoder(nn.Module):
             instruction = observations["rxr_instruction"]
 
         lengths = (instruction != 0.0).long().sum(dim=2)
-        lengths = (lengths != 0.0).long().sum(dim=1)
+        lengths = (lengths != 0.0).long().sum(dim=1).cpu()
 
         packed_seq = nn.utils.rnn.pack_padded_sequence(
             instruction, lengths, batch_first=True, enforce_sorted=False


### PR DESCRIPTION
Hi! Thank you for publishing this great work!
I followed the example in https://github.com/jacobkrantz/VLN-CE#vln-ce-challenge-r2r-data and tried to reproduce the predictions.json. However, there are two main issues in current codebase.
`python run.py --exp-config vlnce_baselines/config/r2r_baselines/test_set_inference.yaml --run-type inference`
1. `AttributeError: 'InstructionData' object has no attribute 'instruction_id'`
```python
File "~/VLN-CE/vlnce_baselines/common/base_il_trainer.py", line 511, in inference
    k = current_episodes[i].instruction.instruction_id
```
This can be resolved by adding `FORMAT: r2r` in `vlnce_baselines/config/r2r_baselines/test_set_inference.yaml`

2. `RuntimeError: 'lengths' argument should be a 1D CPU int64 tensor, but got 1D cuda:0 Long tensor`
```shell
my ENV:
ubuntu 20.04
torch=1.7.0+cu110
```
```
  File "~/anaconda3/envs/vlnce/lib/python3.6/site-packages/torch/nn/utils/rnn.py", line 244, in pack_padded_sequence
    _VF._pack_padded_sequence(input, lengths, batch_first)
RuntimeError: 'lengths' argument should be a 1D CPU int64 tensor, but got 1D cuda:0 Long tensor
```
As set in https://pytorch.org/docs/stable/generated/torch.nn.utils.rnn.pack_padded_sequence.html:
`torch.nn.utils.rnn.pack_padded_sequence(input, lengths, batch_first=False, enforce_sorted=True)` 
lengths ([Tensor](https://pytorch.org/docs/stable/tensors.html#torch.Tensor) or [list](https://docs.python.org/3/library/stdtypes.html#list)([int](https://docs.python.org/3/library/functions.html#int))) – list of sequence lengths of each batch element (must be on the CPU if provided as a tensor).

This can be solved by changing the code in `vlnce_baselines/models/encoders/instruction_encoder.py L78` 
```python
        - lengths = (lengths != 0.0).long().sum(dim=1)
        + lengths = (lengths != 0.0).long().sum(dim=1).cpu()
```